### PR TITLE
Fix #16 - List of markers in cluster added into builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add it to FlutterMap:
       SuperclusterLayer.immutable(
         initialMarkers: markers, // Provide your own
         clusterWidgetSize: const Size(40, 40),
-        builder: (context, markerCount, extraClusterData) {
+        builder: (context, markerCount, markers, extraClusterData) {
           return Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(20.0),

--- a/example/lib/immutable_clustering_page.dart
+++ b/example/lib/immutable_clustering_page.dart
@@ -144,7 +144,7 @@ class _ClusteringManyMarkersPageState extends State<ClusteringManyMarkersPage>
                 ),
               ),
             ),
-            builder: (context, position, markerCount, extraClusterData) {
+            builder: (context, position, markerCount, markers, extraClusterData) {
               return Container(
                 decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(20.0),

--- a/example/lib/mutable_clustering_page.dart
+++ b/example/lib/mutable_clustering_page.dart
@@ -109,7 +109,7 @@ class _MutableClusteringPageState extends State<MutableClusteringPage>
             clusterWidgetSize: const Size(40, 40),
             anchor: AnchorPos.align(AnchorAlign.center),
             calculateAggregatedClusterData: true,
-            builder: (context, position, markerCount, extraClusterData) {
+            builder: (context, position, markerCount, markers, extraClusterData) {
               return Container(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(20.0),

--- a/example/lib/normal_and_clustered_markers_with_popups_page.dart
+++ b/example/lib/normal_and_clustered_markers_with_popups_page.dart
@@ -96,7 +96,7 @@ class _NormalAndClusteredMarkersWithPopupsState
                 ),
               ),
               calculateAggregatedClusterData: true,
-              builder: (context, position, markerCount, extraClusterData) {
+              builder: (context, position, markerCount, markers, extraClusterData) {
                 return Container(
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(20.0),

--- a/example/lib/too_close_to_uncluster_page.dart
+++ b/example/lib/too_close_to_uncluster_page.dart
@@ -125,7 +125,7 @@ class _TooCloseToUnclusterPageState extends State<TooCloseToUnclusterPage>
                   ),
                 ),
               ),
-              builder: (context, position, markerCount, extraClusterData) {
+              builder: (context, position, markerCount, markers, extraClusterData) {
                 return Container(
                   decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(20.0),

--- a/lib/src/layer/cluster_data.dart
+++ b/lib/src/layer/cluster_data.dart
@@ -3,6 +3,7 @@ import 'package:supercluster/supercluster.dart';
 
 class ClusterData extends ClusterDataBase {
   final int markerCount;
+  final List<Marker> markers;
 
   final ClusterDataBase Function(Marker)? _innerExtractor;
   final ClusterDataBase? innerData;
@@ -11,13 +12,15 @@ class ClusterData extends ClusterDataBase {
     Marker marker, {
     ClusterDataBase Function(Marker)? innerExtractor,
   })  : markerCount = 1,
+        markers = [marker],
         _innerExtractor = innerExtractor,
         innerData = innerExtractor?.call(marker);
 
   ClusterData._combined(
-    this.markerCount, {
+    this.markerCount,  {
     ClusterDataBase Function(Marker)? innerExtractor,
     this.innerData,
+    required this.markers,
   }) : _innerExtractor = innerExtractor;
 
   @override
@@ -26,6 +29,7 @@ class ClusterData extends ClusterDataBase {
       markerCount + data.markerCount,
       innerExtractor: _innerExtractor,
       innerData: innerData?.combine(data.innerData!),
+      markers: [...markers, ...data.markers],
     );
   }
 }

--- a/lib/src/layer/supercluster_layer.dart
+++ b/lib/src/layer/supercluster_layer.dart
@@ -38,6 +38,7 @@ typedef ClusterWidgetBuilder = Widget Function(
   BuildContext context,
   LatLng position,
   int markerCount,
+  List<Marker> markers,
   ClusterDataBase? extraClusterData,
 );
 

--- a/lib/src/splay/cluster_splay_delegate.dart
+++ b/lib/src/splay/cluster_splay_delegate.dart
@@ -52,6 +52,7 @@ abstract class ClusterSplayDelegate {
     ClusterWidgetBuilder clusterBuilder,
     LatLng position,
     int markerCount,
+    List<Marker> markers,
     ClusterDataBase? extraClusterData,
     double animationProgress,
   ) =>
@@ -59,6 +60,7 @@ abstract class ClusterSplayDelegate {
         context,
         position,
         markerCount,
+        markers,
         extraClusterData,
       );
 }

--- a/lib/src/splay/spread_cluster_splay_delegate.dart
+++ b/lib/src/splay/spread_cluster_splay_delegate.dart
@@ -14,6 +14,7 @@ typedef SplayClusterWidgetBuilder = Widget Function(
   BuildContext context,
   LatLng position,
   int markerCount,
+  List<Marker> markers,
   ClusterDataBase? extraClusterData,
   double animation,
 );
@@ -56,6 +57,7 @@ class SpreadClusterSplayDelegate extends ClusterSplayDelegate {
     ClusterWidgetBuilder clusterBuilder,
     LatLng position,
     int markerCount,
+    List<Marker> markers,
     ClusterDataBase? extraClusterData,
     double animationProgress,
   ) {
@@ -64,6 +66,7 @@ class SpreadClusterSplayDelegate extends ClusterSplayDelegate {
         context,
         position,
         markerCount,
+        markers,
         extraClusterData,
         animationProgress,
       );
@@ -74,6 +77,7 @@ class SpreadClusterSplayDelegate extends ClusterSplayDelegate {
           context,
           position,
           markerCount,
+          markers,
           extraClusterData,
         ),
       );

--- a/lib/src/widget/cluster_widget.dart
+++ b/lib/src/widget/cluster_widget.dart
@@ -53,6 +53,7 @@ class ClusterWidget extends StatelessWidget {
             context,
             cluster.latLng,
             clusterData.markerCount,
+            clusterData.markers,
             clusterData.innerData,
           ),
         ),

--- a/lib/src/widget/expandable_cluster_widget.dart
+++ b/lib/src/widget/expandable_cluster_widget.dart
@@ -79,7 +79,7 @@ class ExpandableClusterWidget extends StatelessWidget {
               ClusterWidget(
                 mapState: mapState,
                 cluster: expandedCluster.layerCluster,
-                builder: (context, latLng, count, data) =>
+                builder: (context, latLng, count, markers, data) =>
                     expandedCluster.buildCluster(context, builder),
                 onTap: expandedCluster.isExpanded ? onCollapse : () {},
                 size: size,

--- a/lib/src/widget/expanded_cluster.dart
+++ b/lib/src/widget/expanded_cluster.dart
@@ -88,6 +88,7 @@ class ExpandedCluster {
         clusterBuilder,
         layerCluster.latLng,
         clusterData.markerCount,
+        clusterData.markers,
         clusterData.innerData,
         animation.value,
       );


### PR DESCRIPTION
Issue #16  Fix

In order to enable the developer to build the marker based on the list of markers in the cluster, the list of markers is exposed in the builder method. This has been done using an approach very similar to the markerCount to ensure best practices of the package have been observed. 